### PR TITLE
Add docker image + helper scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+bin
+Data
+Examples
+Figures
+Scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM continuumio/anaconda3:latest
+
+ENV PROJ_LIB=/opt/conda/share/proj/ SRC=/usr/local/src/IceVarFigs
+
+RUN apt-get update && \
+    apt-get install -q -y \
+    dvipng texlive texlive-fonts-recommended texlive-lang-cyrillic texlive-lang-english texlive-lang-european texlive-latex-extra
+
+RUN mkdir -p $SRC
+
+COPY requirements.txt $SRC
+
+WORKDIR $SRC
+
+RUN conda config --add channels conda-forge && \
+    conda config --add channels esmvalgroup && \
+    conda config --set channel_priority true && \
+    conda install --file requirements.txt
+
+RUN pip install python-i18n
+
+ENTRYPOINT ["python"]

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Repository contains all of the scripts used in making the figures within (http:/
 Zachary Labe - [Research Website](http://sites.uci.edu/zlabe/) - [@ZLabe](https://twitter.com/ZLabe)
 
 ## Description
++ ```bin/```: Shell scripts
 + ```Data/```: Additional data files not provided by Python URL functions
 + ```Figures/```: Arbitrary figures as examples from listed scripts
 + ```Scripts/```: Main [Python](https://www.python.org/) scripts/functions used in data analysis and plotting. More details are provided in ```explainScripts.txt``` for each script and function.
++ ```Dockerfile```: Docker image manifest for building dependencies
 + ```requirements.txt```: List of environments and modules associated with the most recent version of this project. A Python [Anaconda3 Distribution](https://docs.continuum.io/anaconda/) was used for the analysis. Tools including [NCL 6.4.0](https://www.ncl.ucar.edu/), [CDO](https://code.mpimet.mpg.de/projects/cdo), and [NCO](http://nco.sourceforge.net/) were also used for initial data manipulation. [ImageMagick](https://www.imagemagick.org/script/index.php) is used for most of the animations (GIF). All code has been tested with Python ```3.6```.
 
 ## Data
@@ -52,3 +54,14 @@ Zachary Labe - [Research Website](http://sites.uci.edu/zlabe/) - [@ZLabe](https:
     + Huang, B., Peter W. Thorne, et. al, 2017: Extended Reconstructed Sea Surface Temperature version 5 (ERSSTv5), Upgrades, validations, and intercomparisons. J. Climate, doi: 10.1175/JCLI-D-16-0836.1 [[Publication]](http://journals.ametsoc.org/doi/10.1175/JCLI-D-16-0836.1)
 + NOAA Optimum Interpolation Sea Surface Temperature High Resolution (OISST) v2 : [[DATA]](https://www.esrl.noaa.gov/psd/data/gridded/data.noaa.oisst.v2.highres.html)
     + Reynolds, Richard W., Thomas M. Smith, Chunying Liu, Dudley B. Chelton, Kenneth S. Casey, Michael G. Schlax, 2007: Daily High-Resolution-Blended Analyses for Sea Surface Temperature. J. Climate, 20, 5473-5496. doi: 10.1175/2007JCLI1824.1 [[Publication]](https://journals.ametsoc.org/doi/abs/10.1175/2007JCLI1824.1)
+
+## Docker
+
+###### Build image
+Build an image containing all the dependencies by running `bin/build_image.sh`. Takes optional `VERSION` environment variable, defaults to 'latest'.
+Designed to be used with a volume mount to the repository root so that scripts can be modified without rebuilding the image.
+
+###### Run scripts in container
+Once the image has been built run `bin/run_container.sh <script path>`. Also takes optional `VERSION` environment variable, defaults to 'latest'. Figures will be written to the local `Figures` directory.
+
+Example: `bin/run_container.sh Scripts/Temperature/plot_ArcticTemperatures_Reanalysis.py`

--- a/bin/build_image.sh
+++ b/bin/build_image.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+VERSION="${VERSION:-latest}"
+IMAGE=icevarfigs:$VERSION
+
+docker build -t "$IMAGE" .

--- a/bin/run_container.sh
+++ b/bin/run_container.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+VERSION="${VERSION:-latest}"
+IMAGE=icevarfigs:$VERSION
+
+docker run --rm -v $(pwd):/usr/local/src/IceVarFigs "$IMAGE" "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ defusedxml=0.6.0=py_0
 distributed=2.1.0=py_0
 docutils=0.14=py37_0
 eccodes=2.12.3=h4fa793d_1
-ecmwf-api-client=1.5.4=pypi_0
+ecmwf-api-client=1.5.4=py_0
 entrypoints=0.3=py37_0
 eofs=1.4.0=py_0
 et_xmlfile=1.0.1=py37_0
@@ -188,7 +188,7 @@ openssl=1.1.1c=h516909a_0
 ossuuid=1.6.2=hf484d3e_1000
 owslib=0.18.0=py_0
 packaging=19.0=py37_0
-palettable=3.2.0=pypi_0
+palettable=3.2.0=py_0
 pandas=0.24.2=py37he6710b0_0
 pandoc=2.2.3.2=0
 pandocfilters=1.4.2=py37_1
@@ -308,7 +308,7 @@ webencodings=0.5.1=py37_1
 werkzeug=0.15.4=py_0
 wheel=0.33.4=py37_0
 widgetsnbextension=3.5.0=py37_0
-windspharm=1.7.0=py37_1000
+windspharm=1.7.0=py37_1001
 wrapt=1.11.2=py37h7b6447c_0
 wurlitzer=1.0.2=py37_0
 xarray=0.12.3=py_0


### PR DESCRIPTION
This docker image should make dependency management easier for those who don't use python on a day-to-day basis and lack the tooling, such as anaconda, on their machines. 

Includes some small tweaks to requirements.txt to allow conda to complete installation w/o errors.